### PR TITLE
SLING-9060 New API to improve handling of redirects when serving streams

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>org.apache.sling.api</artifactId>
-    <version>2.22.1-SNAPSHOT</version>
+    <version>2.23.0-SNAPSHOT</version>
 
     <name>Apache Sling API</name>
     <description>

--- a/src/main/java/org/apache/sling/api/redirect/RedirectResolver.java
+++ b/src/main/java/org/apache/sling/api/redirect/RedirectResolver.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.sling.api.redirect;
+
+
+import org.osgi.annotation.versioning.ProviderType;
+
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * <p>
+ * A RedirectResolver resolves a redirect in the context of a request. It resolves that redirect having first been bound
+ * to a Resource. This is typically achieved through the Adapt to mechanism eg resource.adaptTo(RedirectResolver.class).
+ * </p><p>
+ * Implementations should implement an AdapterFactory to perform the adaption to an implementation of this class. That class
+ * should implement the resolve method such that the methods of the Redirect Response are called to define the RedirectResponse.
+ * </p><p>
+ * The implementation of the resolve method indicates that it has successfully resolved a redirect by setting a setting a status code
+ * see the documentation of the RedirectResponse class for more information.
+ * </p>
+ */
+@ProviderType
+public interface RedirectResolver {
+
+    /**
+     * Resolve the redirect for the resource bound to this redirect resolver, in the context of the request.
+     * May decline to perform this operation, but not setting the status code on the redirectResponse.
+     * @param request the context of the resolution given by a request. This is required and must not be null. It will indicate
+     *                where the request came from, including the exposed edge Host and other http request headers. Typically
+     *                and implementation will use these to determine aspects of the redirect redirect. For instance, requests through
+     *                a CDN may redirect differently from request made direct from a service running behind the CDN.
+     * @param redirectResponse the redirect redirect class. This is implemented by the caller and will contain the methods
+     *                         defined in the base class at the time the implementation of the RedirectResolver was written.
+     *                         If methods are added to the RedirectResponse class, they will be added in a way to ensure existing
+     *                         implementations do not need to be updated to continue to work.
+     */
+    void resolve(HttpServletRequest request, RedirectResponse redirectResponse);
+}

--- a/src/main/java/org/apache/sling/api/redirect/RedirectResolver.java
+++ b/src/main/java/org/apache/sling/api/redirect/RedirectResolver.java
@@ -20,7 +20,7 @@ package org.apache.sling.api.redirect;
 
 
 import org.jetbrains.annotations.NotNull;
-import org.osgi.annotation.versioning.ConsumerType;
+import org.osgi.annotation.versioning.ProviderType;
 
 
 import javax.servlet.http.HttpServletRequest;
@@ -38,7 +38,7 @@ import javax.servlet.http.HttpServletRequest;
  * see the documentation of the RedirectResponse class for more information.
  * </p>
  */
-@ConsumerType
+@ProviderType
 public interface RedirectResolver {
 
     /**
@@ -47,7 +47,9 @@ public interface RedirectResolver {
      * @param request the context of the resolution given by a request. This is required and must not be null. It will indicate
      *                where the request came from, including the exposed edge Host and other http request headers. Typically
      *                and implementation will use these to determine aspects of the redirect redirect. For instance, requests through
-     *                a CDN may redirect differently from request made direct from a service running behind the CDN.
+     *                a CDN may redirect differently from request made direct from a service running behind the CDN. Where
+     *                the RedirectResponse does not have support for passing out of band values the request attributes should be used.
+     *                This applies to both the caller and the implementation of this method.
      * @param redirectResponse the redirect redirect class. This is implemented by the caller and will contain the methods
      *                         defined in the base class at the time the implementation of the RedirectResolver was written.
      *                         If methods are added to the RedirectResponse class, they will be added in a way to ensure existing

--- a/src/main/java/org/apache/sling/api/redirect/RedirectResolver.java
+++ b/src/main/java/org/apache/sling/api/redirect/RedirectResolver.java
@@ -19,7 +19,8 @@
 package org.apache.sling.api.redirect;
 
 
-import org.osgi.annotation.versioning.ProviderType;
+import org.jetbrains.annotations.NotNull;
+import org.osgi.annotation.versioning.ConsumerType;
 
 
 import javax.servlet.http.HttpServletRequest;
@@ -36,7 +37,7 @@ import javax.servlet.http.HttpServletRequest;
  * see the documentation of the RedirectResponse class for more information.
  * </p>
  */
-@ProviderType
+@ConsumerType
 public interface RedirectResolver {
 
     /**
@@ -51,5 +52,5 @@ public interface RedirectResolver {
      *                         If methods are added to the RedirectResponse class, they will be added in a way to ensure existing
      *                         implementations do not need to be updated to continue to work.
      */
-    void resolve(HttpServletRequest request, RedirectResponse redirectResponse);
+    void resolve(@NotNull  HttpServletRequest request, @NotNull  RedirectResponse redirectResponse);
 }

--- a/src/main/java/org/apache/sling/api/redirect/RedirectResolver.java
+++ b/src/main/java/org/apache/sling/api/redirect/RedirectResolver.java
@@ -30,8 +30,9 @@ import javax.servlet.http.HttpServletRequest;
  * A RedirectResolver resolves a redirect in the context of a request. It resolves that redirect having first been bound
  * to a Resource. This is typically achieved through the Adapt to mechanism eg resource.adaptTo(RedirectResolver.class).
  * </p><p>
- * Implementations should implement an AdapterFactory to perform the adaption to an implementation of this class. That class
- * should implement the resolve method such that the methods of the Redirect Response are called to define the RedirectResponse.
+ * ResourceProviders should provide implementations of this interface. Alternatively where there is no suitable ResourceProvider
+ * implementations can implement an AdapterFactory to perform the adaption to an implementation of this class. That class
+ * should implement the resolve method such that the methods of the Redirect Response are called to set details the RedirectResponse.
  * </p><p>
  * The implementation of the resolve method indicates that it has successfully resolved a redirect by setting a setting a status code
  * see the documentation of the RedirectResponse class for more information.

--- a/src/main/java/org/apache/sling/api/redirect/RedirectResponse.java
+++ b/src/main/java/org/apache/sling/api/redirect/RedirectResponse.java
@@ -64,19 +64,31 @@ public interface RedirectResponse {
 
 
     /**
-     * Sets an annotation to a value.
-     * Typically an implementation will use annotations to communicate extra values specific to the implementation
-     * without requiring changes to the API. Updates to an annotation will overwrite previous updates to the same key.
-     * @param key the annotation key. This should be namespaced to avoid clashes eg kubernetes.io/rewrite.
-     * @param attribute the value of the attribute
+     * <p>
+     * Sets an attribute on the runtime instance of this RedirectResponse to a value.
+     * </p><p>
+     * An attribute in this context value associated with a key that extends the API without requiring the API to be changed explicitly.
+     * It allows a private contract between two independent implementations to be established quickly to deal with realities
+     * of production allowing an API evolve with a slower cadence than would otherwise be required. Notable examples of this pattern
+     * can be found in the Kubernetes community, although in the Kubernetes community they are called Annotations and have no relation
+     * to Java Annotations. Since this is Java, the term annotation is replaced by attribute.
+     * </p><p>
+     *
+     * These attributes should follow a similar pattern. Used to avoid constantly inflicting API change on everyone, but
+     * with an intention to inform eventual API change.
+     * </p><p>
+     * Typically an implementation will use attributes to communicate extra values specific to the implementation
+     * without requiring changes to the API. Updates to an attribute key value will overwrite previous updates to the same key.
+     * @param key the attribute key. This should be namespaced to avoid clashes eg kubernetes.io/rewrite.
+     * @param value the value of the attribute
      */
-    void setAnnotation(@NotNull  String key, @NotNull  Object attribute);
+    void setAttribute(@NotNull  String key, @NotNull  Object value);
 
 
     /**
-     * Gets the annotation value associated with a key.
-     * @param key the key of the annotation to get, as per the key in setAnnotation.
-     * @return the value of the annotation or null if no annotation value is available for that key.
+     * Gets the attribute value associated with a key.
+     * @param key the key of the attribute to get, as per the key in setAttribute.
+     * @return the value of the attribute or null if no attribute value is available for that key.
      */
-    @Nullable Object getAnnotation(@NotNull String key);
+    @Nullable Object getAttribute(@NotNull String key);
 }

--- a/src/main/java/org/apache/sling/api/redirect/RedirectResponse.java
+++ b/src/main/java/org/apache/sling/api/redirect/RedirectResponse.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.sling.api.redirect;
+
+/**
+ * <p>
+ * A Redirect redirect defines the base class used to hold information to build a redirect.  It is extended
+ * by the caller to RedirectResolver.resolve, and called by the implementation of the RedirectResolver interface.
+ * On return from that call the caller will use the information in the RedirectResponse to perform whatever operation
+ * it needs to perform. Typically this will be returning a http redirect, but there may be other uses.
+ * </p><p>
+ * A class is being used rather than an interface to allow empty setter methods to be added over time.
+ * Callers to RedirectResolver.resolve should override those methods that they need information for. New methods to this
+ * class should be added with empty implementations to ensure that pre-exiting classes extending this method to not
+ * have to be updated.
+ * </p>
+ */
+public class RedirectResponse {
+
+    /**
+     * Value to be used in setStatus to indicate no redirect available for context of the resolution.
+     */
+    public static final int NO_REDIRECT = -1;
+    /**
+     * Set a header on the redirect. This will replace existing headers of the same name.
+     * If called twice, the header will be reset with the latest value.
+     * Multiple headers of the same name are not supported.
+     * @param name the name of the header.
+     * @param value the value of the header.
+     */
+    public void setHeader(String name, String value) {
+    }
+
+    /**
+     * Set the redirect to be used. Will not be sent until the RedirectResponse is returned from the
+     * RedirectResolver.resolver and processed.
+     * @param url the url to set, should be set in the context of a request.
+     */
+    public void setRedirect(String url) {
+
+    }
+
+    /**
+     * Set the status code used in the redirect redirect. Typically 301, but other status codes may be used.
+     * If the status code is not set, or is set to NO_REDIRECT then the redirect will not be acted on.
+     * @param i status code number.
+     */
+    public void setStatus(int i) {
+
+    }
+}

--- a/src/main/java/org/apache/sling/api/redirect/RedirectResponse.java
+++ b/src/main/java/org/apache/sling/api/redirect/RedirectResponse.java
@@ -18,21 +18,21 @@
 package org.apache.sling.api.redirect;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * <p>
- * A Redirect redirect defines the base class used to hold information to build a redirect.  It is extended
+ * A Redirect redirect defines the interface used to hold information to build a redirect.  It is implemented
  * by the caller to RedirectResolver.resolve, and called by the implementation of the RedirectResolver interface.
  * On return from that call the caller will use the information in the RedirectResponse to perform whatever operation
  * it needs to perform. Typically this will be returning a http redirect, but there may be other uses.
  * </p><p>
- * A class is being used rather than an interface to allow empty setter methods to be added over time.
- * Callers to RedirectResolver.resolve should override those methods that they need information for. New methods to this
- * class should be added with empty implementations to ensure that pre-exiting classes extending this method to not
- * have to be updated.
+ * If the implementation finds that it needs to pass values that the interface does not support, it should set
+ * attributes in the request object passed into resolve operation. If the implementation of the RedirectResolver needs to
+ * pass values that the interface does not support, it should also use the request object attributes.
  * </p>
  */
+@ProviderType
 public interface RedirectResponse {
 
     /**
@@ -58,37 +58,9 @@ public interface RedirectResponse {
     void setStatus(int i);
 
     /**
-     * @return true if the instance has resolved after calling RedirectREesolver
+     * @return true if the instance has resolved after calling RedirectResolver
      */
     boolean hasResolved();
 
 
-    /**
-     * <p>
-     * Sets an attribute on the runtime instance of this RedirectResponse to a value.
-     * </p><p>
-     * An attribute in this context value associated with a key that extends the API without requiring the API to be changed explicitly.
-     * It allows a private contract between two independent implementations to be established quickly to deal with realities
-     * of production allowing an API evolve with a slower cadence than would otherwise be required. Notable examples of this pattern
-     * can be found in the Kubernetes community, although in the Kubernetes community they are called Annotations and have no relation
-     * to Java Annotations. Since this is Java, the term annotation is replaced by attribute.
-     * </p><p>
-     *
-     * These attributes should follow a similar pattern. Used to avoid constantly inflicting API change on everyone, but
-     * with an intention to inform eventual API change.
-     * </p><p>
-     * Typically an implementation will use attributes to communicate extra values specific to the implementation
-     * without requiring changes to the API. Updates to an attribute key value will overwrite previous updates to the same key.
-     * @param key the attribute key. This should be namespaced to avoid clashes eg kubernetes.io/rewrite.
-     * @param value the value of the attribute
-     */
-    void setAttribute(@NotNull  String key, @NotNull  Object value);
-
-
-    /**
-     * Gets the attribute value associated with a key.
-     * @param key the key of the attribute to get, as per the key in setAttribute.
-     * @return the value of the attribute or null if no attribute value is available for that key.
-     */
-    @Nullable Object getAttribute(@NotNull String key);
 }

--- a/src/main/java/org/apache/sling/api/redirect/RedirectResponse.java
+++ b/src/main/java/org/apache/sling/api/redirect/RedirectResponse.java
@@ -44,6 +44,7 @@ public class RedirectResponse {
      * @param value the value of the header.
      */
     public void setHeader(String name, String value) {
+        throw new UnsupportedOperationException("Setting headers not supported by this implementation, please override this method to use");
     }
 
     /**
@@ -52,7 +53,7 @@ public class RedirectResponse {
      * @param url the url to set, should be set in the context of a request.
      */
     public void setRedirect(String url) {
-
+        throw new UnsupportedOperationException("Setting a redirect not supported, please override this method to use");
     }
 
     /**
@@ -61,6 +62,6 @@ public class RedirectResponse {
      * @param i status code number.
      */
     public void setStatus(int i) {
-
+        throw new UnsupportedOperationException("Setting a status not supported, please override this method to use");
     }
 }

--- a/src/main/java/org/apache/sling/api/redirect/RedirectResponse.java
+++ b/src/main/java/org/apache/sling/api/redirect/RedirectResponse.java
@@ -17,6 +17,9 @@
 
 package org.apache.sling.api.redirect;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 /**
  * <p>
  * A Redirect redirect defines the base class used to hold information to build a redirect.  It is extended
@@ -30,12 +33,8 @@ package org.apache.sling.api.redirect;
  * have to be updated.
  * </p>
  */
-public class RedirectResponse {
+public interface RedirectResponse {
 
-    /**
-     * Value to be used in setStatus to indicate no redirect available for context of the resolution.
-     */
-    public static final int NO_REDIRECT = -1;
     /**
      * Set a header on the redirect. This will replace existing headers of the same name.
      * If called twice, the header will be reset with the latest value.
@@ -43,25 +42,41 @@ public class RedirectResponse {
      * @param name the name of the header.
      * @param value the value of the header.
      */
-    public void setHeader(String name, String value) {
-        throw new UnsupportedOperationException("Setting headers not supported by this implementation, please override this method to use");
-    }
+    void setHeader(@NotNull  String name, @NotNull  String value);
 
     /**
      * Set the redirect to be used. Will not be sent until the RedirectResponse is returned from the
      * RedirectResolver.resolver and processed.
      * @param url the url to set, should be set in the context of a request.
      */
-    public void setRedirect(String url) {
-        throw new UnsupportedOperationException("Setting a redirect not supported, please override this method to use");
-    }
+    void setRedirect(@NotNull  String url);
 
     /**
      * Set the status code used in the redirect redirect. Typically 301, but other status codes may be used.
-     * If the status code is not set, or is set to NO_REDIRECT then the redirect will not be acted on.
      * @param i status code number.
      */
-    public void setStatus(int i) {
-        throw new UnsupportedOperationException("Setting a status not supported, please override this method to use");
-    }
+    void setStatus(int i);
+
+    /**
+     * @return true if the instance has resolved after calling RedirectREesolver
+     */
+    boolean hasResolved();
+
+
+    /**
+     * Sets an annotation to a value.
+     * Typically an implementation will use annotations to communicate extra values specific to the implementation
+     * without requiring changes to the API. Updates to an annotation will overwrite previous updates to the same key.
+     * @param key the annotation key. This should be namespaced to avoid clashes eg kubernetes.io/rewrite.
+     * @param attribute the value of the attribute
+     */
+    void setAnnotation(@NotNull  String key, @NotNull  Object attribute);
+
+
+    /**
+     * Gets the annotation value associated with a key.
+     * @param key the key of the annotation to get, as per the key in setAnnotation.
+     * @return the value of the annotation or null if no annotation value is available for that key.
+     */
+    @Nullable Object getAnnotation(@NotNull String key);
 }

--- a/src/main/java/org/apache/sling/api/redirect/package-info.java
+++ b/src/main/java/org/apache/sling/api/redirect/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+@Version("1.0.0")
+package org.apache.sling.api.redirect;
+
+import org.osgi.annotation.versioning.Version;
+

--- a/src/test/java/org/apache/sling/api/redirect/RedirectResolverTest.java
+++ b/src/test/java/org/apache/sling/api/redirect/RedirectResolverTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.sling.api.redirect;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RedirectResolverTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+
+
+    /**
+     * Typical usage pattern extend the redirect response in order to use it.
+     */
+    public class RedirectResponseForTests extends RedirectResponse {
+        /**
+         * Status code for the redirect
+         */
+        private int status;
+        /**
+         * The redirect url
+         */
+        private String redirect = null;
+        /**
+         * List of headers
+         */
+        private List<String[]> headers = new ArrayList<String[]>();
+
+        /**
+         *
+         * @return true if after being passed to RedirectResolver.resolve, the resource was resolved to a redirect.
+         */
+        public boolean hasResolved() {
+            return redirect != null;
+        }
+
+        /**
+         * Headers to be added to the redirect
+         * @return iterable of headers in the form of String[2] array.
+         */
+        public Iterable<String[]> getHeaders() {
+            return headers;
+        }
+
+        /**
+         *
+         * @return the redirect url
+         */
+        public String getRedirect() {
+            return redirect;
+        }
+
+        /**
+         *
+         * @return the status code
+         */
+        public int getStatus() {
+            return this.status;
+        }
+
+        @Override
+        public void setStatus(int status) {
+            this.status = status;
+        }
+
+        @Override
+        public void setHeader(String name, String value) {
+            headers.add(new String[]{ name, value});
+        }
+
+        @Override
+        public void setRedirect(String redirect) {
+            this.redirect = redirect;
+        }
+    }
+
+    /**
+     * Only testing the interface here, not testing adaption or the provider.
+     */
+    public class RedirectResolverForTesting implements  RedirectResolver {
+
+        private final String redirect;
+        private final List<String[]> headers;
+        private final int status;
+
+        RedirectResolverForTesting(String redirect, List<String[]> headers, int status) {
+            this.redirect = redirect;
+            this.headers = headers;
+            this.status = status;
+        }
+
+        @Override
+        public void resolve(HttpServletRequest request, RedirectResponse redirectResponse) {
+            for (String[] header: headers) {
+                redirectResponse.setHeader(header[0], header[1]);
+            }
+            redirectResponse.setStatus(status);
+            redirectResponse.setRedirect(redirect);
+        }
+    }
+
+
+    public RedirectResolverTest() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testRedirect() {
+        // this would have been adpated, typically from a resource, not create new.
+        List<String[]> headers = new ArrayList<>();
+        headers.add(new String[] { "x-test", "header"});
+        RedirectResolver redirectResolver = new RedirectResolverForTesting("https://xxx.blobs.com/container/id", headers, 301);
+
+        // test behaviour. This is rather pointless as the behaviour is defined in the test, but
+        // it does ensure that the base class and API are as expected.
+        RedirectResponseForTests redirectResponse = new RedirectResponseForTests();
+        redirectResolver.resolve(request, redirectResponse);
+
+        Assert.assertTrue(redirectResponse.hasResolved());
+        Assert.assertEquals("https://xxx.blobs.com/container/id", redirectResponse.getRedirect());
+        Assert.assertEquals(301, redirectResponse.getStatus());
+    }
+
+    @Test
+    public void testNoRedirect() {
+        // this would have been adpated, typically from a resource, not create new.
+        List<String[]> headers = new ArrayList<>();
+        headers.add(new String[] { "x-test", "header"});
+        RedirectResolver redirectResolver = new RedirectResolverForTesting(null, headers, RedirectResponse.NO_REDIRECT);
+
+        // test behaviour. This is rather pointless as the behaviour is defined in the test, but
+        // it does ensure that the base class and API are as expected.
+        RedirectResponseForTests redirectResponse = new RedirectResponseForTests();
+        redirectResolver.resolve(request, redirectResponse);
+
+        Assert.assertFalse(redirectResponse.hasResolved());
+    }
+
+
+}

--- a/src/test/java/org/apache/sling/api/redirect/RedirectResolverTest.java
+++ b/src/test/java/org/apache/sling/api/redirect/RedirectResolverTest.java
@@ -58,7 +58,7 @@ public class RedirectResolverTest {
         /**
          *
          */
-        private Map<String, Object> annotations = new HashMap<String, Object>();
+        private Map<String, Object> attribute = new HashMap<String, Object>();
 
 
         /**
@@ -95,13 +95,13 @@ public class RedirectResolverTest {
         }
 
         @Override
-        public void setAnnotation(@NotNull String key, @NotNull Object value) {
-            annotations.put(key, value);
+        public void setAttribute(@NotNull String key, @NotNull Object value) {
+            attribute.put(key, value);
         }
 
         @Override
-        public @Nullable Object getAnnotation(@NotNull String key) {
-            return annotations.get(key);
+        public @Nullable Object getAttribute(@NotNull String key) {
+            return attribute.get(key);
         }
 
         @Override

--- a/src/test/java/org/apache/sling/api/redirect/RedirectResolverTest.java
+++ b/src/test/java/org/apache/sling/api/redirect/RedirectResolverTest.java
@@ -19,6 +19,7 @@
 package org.apache.sling.api.redirect;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -27,6 +28,8 @@ import org.mockito.MockitoAnnotations;
 import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 public class RedirectResolverTest {
 
@@ -38,7 +41,7 @@ public class RedirectResolverTest {
     /**
      * Typical usage pattern extend the redirect response in order to use it.
      */
-    public class RedirectResponseForTests extends RedirectResponse {
+    public class RedirectResponseForTests implements RedirectResponse {
         /**
          * Status code for the redirect
          */
@@ -54,11 +57,9 @@ public class RedirectResolverTest {
 
         /**
          *
-         * @return true if after being passed to RedirectResolver.resolve, the resource was resolved to a redirect.
          */
-        public boolean hasResolved() {
-            return redirect != null;
-        }
+        private Map<String, Object> annotations = new HashMap<String, Object>();
+
 
         /**
          * Headers to be added to the redirect
@@ -82,6 +83,25 @@ public class RedirectResolverTest {
          */
         public int getStatus() {
             return this.status;
+        }
+
+        /**
+         *
+         * @return true if after being passed to RedirectResolver.resolve, the resource was resolved to a redirect.
+         */
+        @Override
+        public boolean hasResolved() {
+            return redirect != null;
+        }
+
+        @Override
+        public void setAnnotation(@NotNull String key, @NotNull Object value) {
+            annotations.put(key, value);
+        }
+
+        @Override
+        public @Nullable Object getAnnotation(@NotNull String key) {
+            return annotations.get(key);
         }
 
         @Override
@@ -152,7 +172,7 @@ public class RedirectResolverTest {
         // this would have been adpated, typically from a resource, not create new.
         List<String[]> headers = new ArrayList<>();
         headers.add(new String[] { "x-test", "header"});
-        RedirectResolver redirectResolver = new RedirectResolverForTesting(null, headers, RedirectResponse.NO_REDIRECT);
+        RedirectResolver redirectResolver = new RedirectResolverForTesting(null, headers, -1);
 
         // test behaviour. This is rather pointless as the behaviour is defined in the test, but
         // it does ensure that the base class and API are as expected.

--- a/src/test/java/org/apache/sling/api/redirect/RedirectResolverTest.java
+++ b/src/test/java/org/apache/sling/api/redirect/RedirectResolverTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.sling.api.redirect;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -115,7 +116,7 @@ public class RedirectResolverTest {
         }
 
         @Override
-        public void resolve(HttpServletRequest request, RedirectResponse redirectResponse) {
+        public void resolve(@NotNull HttpServletRequest request, @NotNull RedirectResponse redirectResponse) {
             for (String[] header: headers) {
                 redirectResponse.setHeader(header[0], header[1]);
             }

--- a/src/test/java/org/apache/sling/api/redirect/RedirectResolverTest.java
+++ b/src/test/java/org/apache/sling/api/redirect/RedirectResolverTest.java
@@ -55,10 +55,6 @@ public class RedirectResolverTest {
          */
         private List<String[]> headers = new ArrayList<String[]>();
 
-        /**
-         *
-         */
-        private Map<String, Object> attribute = new HashMap<String, Object>();
 
 
         /**
@@ -94,15 +90,6 @@ public class RedirectResolverTest {
             return redirect != null;
         }
 
-        @Override
-        public void setAttribute(@NotNull String key, @NotNull Object value) {
-            attribute.put(key, value);
-        }
-
-        @Override
-        public @Nullable Object getAttribute(@NotNull String key) {
-            return attribute.get(key);
-        }
 
         @Override
         public void setStatus(int status) {


### PR DESCRIPTION
Adds an API to improve redirect handling so that future implementations get the context of the request and improves the call signature to allow adaptations without changing the API. Ultimately this will replace the URIProvider based mechanism.