### PR TITLE
SLING-9077: implemented an optimised PathSet with O(n+m)

### DIFF
--- a/src/main/java/org/apache/sling/api/resource/path/PathSet.java
+++ b/src/main/java/org/apache/sling/api/resource/path/PathSet.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.sling.api.resource.ResourceUtil;
+import org.apache.sling.api.wrappers.IteratorWrapper;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -219,7 +220,7 @@ public class PathSet implements Iterable<Path> {
      */
     @Override
     public Iterator<Path> iterator() {
-        return this.paths.iterator();
+        return new UnmodifiableIterator<>(this.paths.iterator());
     }
 
     @Override
@@ -435,6 +436,30 @@ public class PathSet implements Iterable<Path> {
         public void setPayload(Path payload) {
             this.payload = payload;
             this.children = null;
+        }
+    }
+
+    /**
+     * An implementation of {@link IteratorWrapper} that completely denies to
+     * delete elements from it using {@link Iterator#remove()}.
+     *
+     * @param <T>
+     */
+    private static class UnmodifiableIterator<T> extends IteratorWrapper<T> {
+
+        /**
+         * Creates an {@link Iterator} that does not allow to call
+         * {@link Iterator#remove()}.
+         *
+         * @param wrappedIterator the wrapped iterator
+         */
+        public UnmodifiableIterator(Iterator<T> wrappedIterator) {
+            super(wrappedIterator);
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/src/main/java/org/apache/sling/api/resource/path/PathSet.java
+++ b/src/main/java/org/apache/sling/api/resource/path/PathSet.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.sling.api.resource.ResourceUtil;
-import org.apache.sling.api.wrappers.IteratorWrapper;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -133,13 +132,13 @@ public class PathSet implements Iterable<Path> {
         }
     }
 
-    private final Iterable<Path> paths;
+    private final Collection<Path> paths;
 
     /**
      * Create a path set from a set of paths
      * @param paths A set of paths
      */
-    private PathSet(final Iterable<Path> paths) {
+    private PathSet(final Collection<Path> paths) {
         this.paths = paths;
     }
 
@@ -220,7 +219,7 @@ public class PathSet implements Iterable<Path> {
      */
     @Override
     public Iterator<Path> iterator() {
-        return new UnmodifiableIterator<>(this.paths.iterator());
+        return Collections.unmodifiableCollection(this.paths).iterator();
     }
 
     @Override
@@ -387,7 +386,7 @@ public class PathSet implements Iterable<Path> {
                     if (patterns != null) {
                         paths = Stream.concat(patterns.stream(), paths);
                     }
-                    return new PathSet(paths::iterator);
+                    return new PathSet(paths.collect(Collectors.toList()));
                 }
             } finally {
                 patterns = null;
@@ -436,30 +435,6 @@ public class PathSet implements Iterable<Path> {
         public void setPayload(Path payload) {
             this.payload = payload;
             this.children = null;
-        }
-    }
-
-    /**
-     * An implementation of {@link IteratorWrapper} that completely denies to
-     * delete elements from it using {@link Iterator#remove()}.
-     *
-     * @param <T>
-     */
-    private static class UnmodifiableIterator<T> extends IteratorWrapper<T> {
-
-        /**
-         * Creates an {@link Iterator} that does not allow to call
-         * {@link Iterator#remove()}.
-         *
-         * @param wrappedIterator the wrapped iterator
-         */
-        public UnmodifiableIterator(Iterator<T> wrappedIterator) {
-            super(wrappedIterator);
-        }
-
-        @Override
-        public void remove() {
-            throw new UnsupportedOperationException();
         }
     }
 }

--- a/src/test/java/org/apache/sling/api/resource/path/PathSetTest.java
+++ b/src/test/java/org/apache/sling/api/resource/path/PathSetTest.java
@@ -79,11 +79,25 @@ public class PathSetTest {
     }
 
     @Test public void testOptimize() {
-        final PathSet set1 = PathSet.fromStrings("/", "/a", "/z", "/x/y");
-        assertEqualSets(set1, "/");
+        // small sets
+        PathSet set = PathSet.fromStrings("/", "/a", "/z");
+        assertEqualSets(set, "/");
 
-        final PathSet set2 = PathSet.fromStrings("/a", "/a/x/y", "/z", "/x/y", "/a2");
-        assertEqualSets(set2, "/a", "/z", "/a2", "/x/y");
+        set = PathSet.fromStrings("/a", "/b", "/c");
+        assertEqualSets(set, "/a", "/b", "/c");
+
+        // large sets
+        set = PathSet.fromStrings("/a", "/a/x/y", "/z", "/x/y", "/a2");
+        assertEqualSets(set, "/a", "/z", "/a2", "/x/y");
+
+        set = PathSet.fromStrings("/c/a/ab", "/c/b/bc", "/c/a", "/c", "/c/d/de");
+        assertEqualSets(set, "/c");
+
+        set = PathSet.fromStrings("/c/a/ab", "/c/b/bc", "/c/d/ab", "/c/d/ab/c", "glob:/c/*/ab", "/c/e/ab");
+        assertEqualSets(set, "/c/b/bc", "glob:/c/*/ab");
+
+        set = PathSet.fromStrings("glob:/a/*","glob:/b/*","glob:/c/*","glob:/d/*");
+        assertEqualSets(set, "glob:/a/*","glob:/b/*","glob:/c/*","glob:/d/*");
     }
 
     @Test public void testMatching() {

--- a/src/test/java/org/apache/sling/api/resource/path/PathSetTest.java
+++ b/src/test/java/org/apache/sling/api/resource/path/PathSetTest.java
@@ -144,4 +144,9 @@ public class PathSetTest {
         final PathSet result = set.getSubset(filter);
         assertEqualSets(result, "/libs/foo/bar", "/apps/foo/bar");
     }
+
+
+    @Test(expected = UnsupportedOperationException.class) public void testImmutability() {
+        PathSet.fromStrings("/foo", "/bar").iterator().remove();
+    }
 }


### PR DESCRIPTION
There are various use cases for PathSets, most of them involve small sets of
paths or glob patterns. In those cases a polynominal time complexity for
optimising the PathSet does not harm performance noticeable. Other use cases
on the other hand require large sets of only paths for which a linear time
complexity can be achieved. Here a compromise between the both use  cases was
implemented. For small sets the simple but expensive optimisation is applied
and once the size of the PathSet exceeds the theoretical bound of the simple
algorithm it switches to the less expensive implementation.