### PR TITLE
SLING-11067 extend URIProvider by method returning Optional

### DIFF
--- a/src/main/java/org/apache/sling/api/resource/external/ExternalizableInputStream.java
+++ b/src/main/java/org/apache/sling/api/resource/external/ExternalizableInputStream.java
@@ -22,23 +22,25 @@ package org.apache.sling.api.resource.external;
 import java.net.URI;
 
 import org.jetbrains.annotations.NotNull;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * This interface is normally used to extend an InputStream to indicate that it has a URI form that could
  * be used in place of the InputStream if desired. It is used in situations where the internal of a ResourceProvider
- * wants to offload IO to channels that do not pass through the JVM. The URI that is returned may have restrictions
+ * wants to offload I/O to channels that do not pass through the JVM. The URI that is returned may have restrictions
  * imposed on it requiring it to be used immediately. Do not store the URI for later usage as it will, in most cases,
  * have expired.
- *
+ * Every implementation implementing {@code ExternalizableInputStream} should rely on {@link URIProviders} for getting the URI.
+ * @since 1.0.0 (Sling API Bundle 2.16.4)
  */
+@ProviderType
 public interface ExternalizableInputStream {
 
     /**
      * Get a URI that is specific to the current session, and may be used in any context internal or external. The URI must not
-     * be stored and must not be shared between clients. For a wider range of URIs the caller should use the URIProvider class
+     * be stored and must not be shared between clients. For a wider range of URIs the caller should use the {@link URIProvider} class
      * directly and not this interface.
      * @return a URI intended for any network context.
      */
     @NotNull URI getURI();
-
 }

--- a/src/main/java/org/apache/sling/api/resource/external/ExternalizableInputStream.java
+++ b/src/main/java/org/apache/sling/api/resource/external/ExternalizableInputStream.java
@@ -22,7 +22,7 @@ package org.apache.sling.api.resource.external;
 import java.net.URI;
 
 import org.jetbrains.annotations.NotNull;
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 /**
  * This interface is normally used to extend an InputStream to indicate that it has a URI form that could
@@ -33,7 +33,7 @@ import org.osgi.annotation.versioning.ProviderType;
  * Every implementation implementing {@code ExternalizableInputStream} should rely on {@link URIProviders} for getting the URI.
  * @since 1.0.0 (Sling API Bundle 2.16.4)
  */
-@ProviderType
+@ConsumerType
 public interface ExternalizableInputStream {
 
     /**

--- a/src/main/java/org/apache/sling/api/resource/external/URIProvider.java
+++ b/src/main/java/org/apache/sling/api/resource/external/URIProvider.java
@@ -93,7 +93,7 @@ public interface URIProvider {
      * @param operation the required operation.
      * @return a URI if the resource has a URI suitable for the requested scope and operation, otherwise the implementation should throw an {@link IllegalArgumentException}.
      * @throws IllegalArgumentException if a URI for the requested scope and operation cannot be provided to the caller.
-     * @deprecated Use {@link #getOptionalUriForResource(Resource, Scope, Operation)} instead.
+     * @deprecated Use {@link #toOptionalUri(Resource, Scope, Operation)} instead.
      */
     @Deprecated
     @NotNull URI toURI(@NotNull Resource resource, @NotNull Scope scope, @NotNull Operation operation);
@@ -106,7 +106,7 @@ public interface URIProvider {
      * @return a URI if the resource has a URI suitable for the requested scope and operation, otherwise {@link Optional#empty()}.
      * @since 1.1.0 (Sling API Bundle 2.25.0)
      */
-    default @NotNull Optional<URI> getOptionalUriForResource(@NotNull Resource resource, @NotNull Scope scope, @NotNull Operation operation) {
+    default @NotNull Optional<URI> toOptionalUri(@NotNull Resource resource, @NotNull Scope scope, @NotNull Operation operation) {
         try {
             return Optional.of(toURI(resource, scope, operation));
         } catch (IllegalArgumentException e) {

--- a/src/main/java/org/apache/sling/api/resource/external/package-info.java
+++ b/src/main/java/org/apache/sling/api/resource/external/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@Version("1.0.2")
+@Version("1.1.0")
 package org.apache.sling.api.resource.external;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
Prevents throwing exception if URIProvider does not have URI for
resource. Cleanup some javadoc