### PR TITLE
SLING-11347 SlingUriBuilder preserve mapped resource path

### DIFF
--- a/src/main/java/org/apache/sling/api/uri/package-info.java
+++ b/src/main/java/org/apache/sling/api/uri/package-info.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@Version("1.3.0")
+@Version("1.3.1")
 package org.apache.sling.api.uri;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
Use Case:

Use the SlingUriBuilder.createFrom(request) call from a servlet in order to create a SlingUri from the current request in order to change the selectors (or extension) and then redirect to that new uri value.

Expected:

When calling SlingUriBuilder.createFrom(request) for a mapped request path, the built SlingUri object should return the original mapped path from the getResourcePath() call instead of the resource path that was resolved from the mapped path.

This should help to avoid accidentally switching from /folder/page1 to /content/folder/page1 in the SlingUri output.