### PR TITLE
SLING-11531 add RequestParameter factory to Builders

### DIFF
--- a/src/main/java/org/apache/sling/api/request/builder/Builders.java
+++ b/src/main/java/org/apache/sling/api/request/builder/Builders.java
@@ -18,7 +18,11 @@
  */
 package org.apache.sling.api.request.builder;
 
+import java.nio.charset.Charset;
+
+import org.apache.sling.api.request.RequestParameter;
 import org.apache.sling.api.request.RequestProgressTracker;
+import org.apache.sling.api.request.builder.impl.RequestParameterImpl;
 import org.apache.sling.api.request.builder.impl.RequestProgressTrackerImpl;
 import org.apache.sling.api.request.builder.impl.SlingHttpServletRequestImpl;
 import org.apache.sling.api.request.builder.impl.SlingHttpServletResponseImpl;
@@ -62,5 +66,30 @@ public final class Builders {
      */
     public static @NotNull RequestProgressTracker newRequestProgressTracker() {
         return new RequestProgressTrackerImpl();
+    }
+
+    /**
+     * Creates a new request parameter
+     *
+     * @param name the parameter name
+     * @param value the parameter value
+     * @return a request parameter
+     * @since 1.2 (Sling API Bundle 2.26.2)
+     */
+    public static @NotNull RequestParameter newRequestParameter(String name, String value) {
+        return new RequestParameterImpl(name, value);
+    }
+
+    /**
+     * Creates a new request parameter
+     *
+     * @param name the parameter name
+     * @param value the parameter value
+     * @param encoding the charset of the value
+     * @return a request parameter
+     * @since 1.2 (Sling API Bundle 2.26.2)
+     */
+    public static @NotNull RequestParameter newRequestParameter(String name, String value, Charset encoding) {
+        return new RequestParameterImpl(name, value, encoding);
     }
 }

--- a/src/main/java/org/apache/sling/api/request/builder/impl/RequestParameterImpl.java
+++ b/src/main/java/org/apache/sling/api/request/builder/impl/RequestParameterImpl.java
@@ -21,6 +21,7 @@ package org.apache.sling.api.request.builder.impl;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.sling.api.request.RequestParameter;
@@ -34,10 +35,16 @@ public class RequestParameterImpl implements RequestParameter {
 
     private final String name;
     private final String value;
+    private final Charset encoding;
 
     public RequestParameterImpl(final String name, final String value) {
+        this(name, value, StandardCharsets.UTF_8);
+    }
+
+    public RequestParameterImpl(final String name, final String value, final Charset encoding) {
         this.name = name;
         this.value = value;
+        this.encoding = encoding;
     }
 
     @Override
@@ -47,7 +54,7 @@ public class RequestParameterImpl implements RequestParameter {
 
     @Override
     public byte[] get() {
-        return this.value.getBytes(StandardCharsets.UTF_8);
+        return this.value.getBytes(encoding);
     }
 
     @Override

--- a/src/main/java/org/apache/sling/api/request/builder/package-info.java
+++ b/src/main/java/org/apache/sling/api/request/builder/package-info.java
@@ -16,5 +16,5 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@org.osgi.annotation.versioning.Version("1.1")
+@org.osgi.annotation.versioning.Version("1.2")
 package org.apache.sling.api.request.builder;

--- a/src/test/java/org/apache/sling/api/request/builder/BuildersTest.java
+++ b/src/test/java/org/apache/sling/api/request/builder/BuildersTest.java
@@ -23,9 +23,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.request.RequestParameter;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -70,4 +75,25 @@ public class BuildersTest {
     public void createRequestProgressTracker() {
         assertNotNull(Builders.newRequestProgressTracker());
     }
+
+    @Test
+    public void createRequestParameter() throws UnsupportedEncodingException {
+        @NotNull
+        RequestParameter rp = Builders.newRequestParameter("key", "value");
+        assertNotNull(rp);
+        assertEquals("key", rp.getName());
+        assertEquals("value", rp.getString());
+        assertEquals("value", rp.getString(StandardCharsets.UTF_8.name()));
+    }
+
+    @Test
+    public void createRequestParameterWithCharset() throws UnsupportedEncodingException {
+        @NotNull
+        RequestParameter rp = Builders.newRequestParameter("key", new String("value".getBytes(StandardCharsets.UTF_16), StandardCharsets.UTF_16), StandardCharsets.UTF_16);
+        assertNotNull(rp);
+        assertEquals("key", rp.getName());
+        assertEquals("value", rp.getString());
+        assertEquals("value", rp.getString(StandardCharsets.UTF_16.name()));
+    }
+
 }


### PR DESCRIPTION
As discussed at [SLING-11525](https://issues.apache.org/jira/browse/SLING-11525)

Expected:

Add a newRequestParameter factory method to the [Builders](https://github.com/apache/sling-org-apache-sling-api/blob/master/src/main/java/org/apache/sling/api/request/builder/Builders.java) class from sling.api so the duplicated RequestParameterImpl class can be removed from the org.apache.sling.jcr.jackrabbit.usermanager bundle and use the new factory instead.

The motivation for this is to remove the tight coupling of the org.apache.sling.api.request package between the sling.api and usemanager bundles that is caused by implementing The RequestParameter interface that has been annotated as a ProviderType. 

Without this change, every time that the exported version number of the o.a.sling.api.request package changes, the usermanager must bump the version of the dependency and release a new usermanger version to satisfy the narrow version range that was being imported for that package.