### PR TITLE
SLING-11546: Edited calendar toString method so it explicitly adds th…

### DIFF
--- a/src/main/java/org/apache/sling/api/wrappers/impl/ObjectConverter.java
+++ b/src/main/java/org/apache/sling/api/wrappers/impl/ObjectConverter.java
@@ -80,7 +80,7 @@ public final class ObjectConverter {
     }
 
     private static String toString(Calendar cal) {
-        return cal.toInstant().toString();
+        return ZonedDateTime.ofInstant(Instant.ofEpochMilli(cal.getTimeInMillis()), cal.getTimeZone().toZoneId()).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
     }
 
     private static String toString(Date cal) {


### PR DESCRIPTION
…e timezone to the string. This fixes the issue of losing timezone information.

Also tested if any of the other converts suffer from the same issue.