### PR TITLE
SLING-12062 add LazyBindings.putOnly

### DIFF
--- a/src/main/java/org/apache/sling/api/scripting/LazyBindings.java
+++ b/src/main/java/org/apache/sling/api/scripting/LazyBindings.java
@@ -75,6 +75,20 @@ public class LazyBindings extends HashMap<String, Object> implements Bindings {
     @Override
     public Object put(String key, Object value) {
         Object previous = this.get(key);
+        putOnly(key, value);
+        return previous;
+    }
+
+    /**
+     * Set a named value; identical with {@link #put(String, Object)} but does not return (and evaluate)
+     * any previous value set.
+     * This is an extension of the LazyBindings implementation and can be beneficial if the supplied value is a Supplier, for which the 
+     * evaluation can be costly.
+     * 
+     * @param key the name associated with the value
+     * @param value the value associated with the name
+     */
+    public void putOnly(String key, Object value) {
         if (value instanceof LazyBindings.Supplier) {
             suppliers.put(key, (LazyBindings.Supplier) value);
             super.remove(key);
@@ -82,13 +96,12 @@ public class LazyBindings extends HashMap<String, Object> implements Bindings {
             super.put(key, value);
             suppliers.remove(key);
         }
-        return previous;
     }
 
     @Override
     public void putAll(Map<? extends String, ?> toMerge) {
         for (Entry<? extends String, ?> entry : toMerge.entrySet()) {
-            put(entry.getKey(), entry.getValue());
+            putOnly(entry.getKey(), entry.getValue());
         }
     }
 

--- a/src/main/java/org/apache/sling/api/scripting/SlingBindings.java
+++ b/src/main/java/org/apache/sling/api/scripting/SlingBindings.java
@@ -182,7 +182,7 @@ public class SlingBindings extends LazyBindings {
      */
     protected void safePut(final String key, final Object value) {
         if ( value != null ) {
-            this.put(key, value);
+            this.putOnly(key, value);
         }
     }
 
@@ -191,7 +191,7 @@ public class SlingBindings extends LazyBindings {
      * @param flush Whether to flush or not
      */
     public void setFlush(boolean flush) {
-        put(FLUSH, flush);
+        putOnly(FLUSH, flush);
     }
 
     /**

--- a/src/main/java/org/apache/sling/api/scripting/package-info.java
+++ b/src/main/java/org/apache/sling/api/scripting/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@Version("2.5.0")
+@Version("2.6.0")
 package org.apache.sling.api.scripting;
 
 import org.osgi.annotation.versioning.Version;

--- a/src/test/java/org/apache/sling/api/scripting/LazyBindingsTest.java
+++ b/src/test/java/org/apache/sling/api/scripting/LazyBindingsTest.java
@@ -35,6 +35,7 @@ import java.util.function.Supplier;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class LazyBindingsTest {
     private static final String THE_QUESTION = "What is The Answer to the Ultimate Question of Life, The Universe, and Everything?";
@@ -218,6 +219,31 @@ public class LazyBindingsTest {
             }
         });
         assertEquals("lazybar", bindings.get("foo"));
+    }
+
+    @Test
+    public void testPut_vs_PutOnly() {
+        final LazyBindings bindings = new LazyBindings();
+
+        Supplier supplierPut = Mockito.spy(new LazyBindings.Supplier() {
+            @Override
+            public Object get() {
+                return "bar";
+            }
+        });
+        bindings.put("put", supplierPut);
+        bindings.put("put", supplierPut);
+        Mockito.verify(supplierPut, Mockito.times(1)).get();
+
+        Supplier supplierPutOnly = Mockito.spy(new LazyBindings.Supplier() {
+            @Override
+            public Object get() {
+                return "bar";
+            }
+        });
+        bindings.putOnly("putOnly", supplierPutOnly);
+        bindings.putOnly("putOnly", supplierPutOnly);
+        Mockito.verify(supplierPutOnly, Mockito.never()).get();
     }
 
     private class TestSupplier implements LazyBindings.Supplier {

--- a/src/test/java/org/apache/sling/api/scripting/SlingBindingsTest.java
+++ b/src/test/java/org/apache/sling/api/scripting/SlingBindingsTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.api.scripting;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.PrintWriter;
+import java.io.Reader;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+
+public class SlingBindingsTest {
+    
+    SlingBindings bindings = new SlingBindings();
+    
+    @Test
+    public void test_Flush() {
+        assertFalse(bindings.getFlush());
+        bindings.setFlush(true);
+        assertTrue(bindings.getFlush());
+    }
+    
+    @Test
+    public void test_Log() {
+        Logger logger = Mockito.mock(Logger.class);
+        assertNull(bindings.getLog());
+        bindings.setLog(null);
+        assertNull(bindings.getLog());
+        bindings.setLog(logger);
+        assertEquals(logger,bindings.getLog());
+    }
+    
+    @Test
+    public void test_out() {
+        PrintWriter printWriter = Mockito.mock(PrintWriter.class);
+        assertNull(bindings.getOut());
+        bindings.setOut(null);
+        assertNull(bindings.getOut());
+        bindings.setOut(printWriter);
+        assertEquals(printWriter,bindings.getOut());
+    }
+    
+    @Test
+    public void test_request() {
+        SlingHttpServletRequest request = Mockito.mock(SlingHttpServletRequest.class);
+        assertNull(bindings.getRequest());
+        bindings.setRequest(null);
+        assertNull(bindings.getRequest());
+        bindings.setRequest(request);
+        assertEquals(request,bindings.getRequest());
+    }
+    
+    @Test
+    public void test_reader() {
+        Reader reader = Mockito.mock(Reader.class);
+        assertNull(bindings.getReader());
+        bindings.setReader(null);
+        assertNull(bindings.getReader());
+        bindings.setReader(reader);
+        assertEquals(reader,bindings.getReader());
+    }
+    
+    @Test
+    public void test_resource() {
+        Resource resource = Mockito.mock(Resource.class);
+        assertNull(bindings.getResource());
+        bindings.setResource(null);
+        assertNull(bindings.getResource());
+        bindings.setResource(resource);
+        assertEquals(resource,bindings.getResource());
+    }
+    
+    @Test
+    public void test_resourceresolver() {
+        ResourceResolver resolver = Mockito.mock(ResourceResolver.class);
+        assertNull(bindings.getResourceResolver());
+        bindings.setResourceResolver(null);
+        assertNull(bindings.getResourceResolver());
+        bindings.setResourceResolver(resolver);
+        assertEquals(resolver,bindings.getResourceResolver());
+    }
+    
+    @Test
+    public void test_response() {
+        SlingHttpServletResponse response = Mockito.mock(SlingHttpServletResponse.class);
+        assertNull(bindings.getResponse());
+        bindings.setResponse(null);
+        assertNull(bindings.getResponse());
+        bindings.setResponse(response);
+        assertEquals(response, bindings.getResponse());
+    }
+    
+    @Test
+    public void test_sling() {
+        SlingScriptHelper sling = Mockito.mock(SlingScriptHelper.class);
+        assertNull(bindings.getSling());
+        bindings.setSling(null);
+        assertNull(bindings.getSling());
+        bindings.setSling(sling);
+        assertEquals(sling,bindings.getSling());
+    }
+    
+    @Test
+    public void test_nonMatchingClass() {
+        SlingHttpServletResponse response = Mockito.mock(SlingHttpServletResponse.class);
+        bindings.setResponse(response);
+        assertEquals(response,bindings.getResponse());
+        
+        // manually put a wrong type 
+        SlingHttpServletRequest request = Mockito.mock(SlingHttpServletRequest.class);
+        bindings.put(SlingBindings.RESPONSE, request);
+        // incorrect type, so a null is expected
+        assertNull(bindings.getResponse());
+        
+        
+        
+        
+    }
+    
+    
+}

--- a/src/test/java/org/apache/sling/api/scripting/SlingBindingsTest.java
+++ b/src/test/java/org/apache/sling/api/scripting/SlingBindingsTest.java
@@ -136,11 +136,5 @@ public class SlingBindingsTest {
         bindings.put(SlingBindings.RESPONSE, request);
         // incorrect type, so a null is expected
         assertNull(bindings.getResponse());
-        
-        
-        
-        
     }
-    
-    
 }


### PR DESCRIPTION
the existing ```LazyBindings.put``` returns any previously stored value for the same name; if that previous value was provided as a ```Supplier``` it is resolved during that process. But in many cases the return value of ```put``` is ignored, so this resolution of a supplier is overhead.  

This addition to the API adds a ```putOnly``` method, which has the same semantics as the existing ```put``` it does not (resolve and) return any existing value.