### PR TITLE
SLING-12781 Expose resource type via getValueMap()

### DIFF
--- a/src/main/java/org/apache/sling/api/resource/ModifiableValueMap.java
+++ b/src/main/java/org/apache/sling/api/resource/ModifiableValueMap.java
@@ -59,11 +59,12 @@ import org.osgi.annotation.versioning.ConsumerType;
  * </ul>
  * <p>
  *
- * A modifiable value map should value {@link ResourceResolver#PROPERTY_RESOURCE_TYPE}
- * to set the resource type of a resource.
+ * A modifiable value map should consider property {@value ResourceResolver#PROPERTY_RESOURCE_TYPE}
+ * to set the resource type of a resource and {@value ResourceResolver#PROPERTY_RESOURCE_SUPER_TYPE}
+ * to set the optional super type.
  * <p>
  * A modifiable value map must not support deep writes. A call of a modification method
- * with a path should result in an IllegalArgumentException.
+ * with a path (i.e. a key containing a slash) should result in an {@link IllegalArgumentException}.
  *
  * @since 2.2  (Sling API Bundle 2.2.0)
  */

--- a/src/main/java/org/apache/sling/api/resource/Resource.java
+++ b/src/main/java/org/apache/sling/api/resource/Resource.java
@@ -222,6 +222,7 @@ public interface Resource extends Adaptable {
     /**
      * Returns a value map for this resource.
      * The value map allows to read the properties of the resource.
+     * Each map is containing at least the mandatory property {@value ResourceResolver#PROPERTY_RESOURCE_TYPE}.
      * @return A value map
      * @since 2.5 (Sling API Bundle 2.7.0)
      */

--- a/src/main/java/org/apache/sling/api/resource/ResourceResolver.java
+++ b/src/main/java/org/apache/sling/api/resource/ResourceResolver.java
@@ -168,15 +168,22 @@ public interface ResourceResolver extends Adaptable, Closeable {
     String USER_IMPERSONATOR = "user.impersonator";
 
     /**
-     * This is the suggested property to be used for setting the resource type
+     * This is the property to be used for setting the resource type
      * of a resource during either creation ({@link #create(Resource, String, Map)})
-     * or modifying ({@link ModifiableValueMap}).
-     * However the exact way to set the resource type of a resource is defined
-     * by the underlying resource provider. It should value this property but
-     * is not required to do so.
+     * or modifying ({@link ModifiableValueMap}). This property is usually also exposed
+     * via {@link Resource#getValueMap()}.
      * @since 2.3 (Sling API Bundle 2.4.0)
      */
     String PROPERTY_RESOURCE_TYPE = "sling:resourceType";
+
+    /**
+     * This is property to be used for setting the resource super type
+     * of a resource during either creation ({@link #create(Resource, String, Map)})
+     * or modifying ({@link ModifiableValueMap}). This property is usually also exposed
+     * via {@link Resource#getValueMap()}.
+     * @since 2.15.0 (Sling API Bundle 3.0.0)
+     */
+    String PROPERTY_RESOURCE_SUPER_TYPE = "sling:resourceSuperType";
 
     /**
      * Resolves the resource from the given <code>absPath</code> optionally
@@ -769,10 +776,12 @@ public interface ResourceResolver extends Adaptable, Closeable {
     /**
      * Add a child resource to the given parent resource.
      * The changes are transient and require a call to {@link #commit()} for persisting.
+     * The mandatory resource type is either determined by the property {@value ResourceResolver#PROPERTY_RESOURCE_TYPE} or set by the underlying resource provider to some value.
+     * The optional resource super type is determined by the property {@value ResourceResolver#PROPERTY_RESOURCE_SUPER_TYPE}.
      *
      * @param parent The parent resource
      * @param name   The name of the child resource - this is a plain name, not a path!
-     * @param properties Optional properties for the resource
+     * @param properties Optional properties for the resource (may be <code>null</code>).
      * @return The new resource
      *
      * @throws NullPointerException if the resource parameter or name parameter is null

--- a/src/test/java/org/apache/sling/api/resource/SyntheticResourceTest.java
+++ b/src/test/java/org/apache/sling/api/resource/SyntheticResourceTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.api.resource;
+
+import java.util.Map;
+
+import org.apache.sling.api.adapter.AdapterManager;
+import org.apache.sling.api.adapter.SlingAdaptable;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+public class SyntheticResourceTest {
+
+    @Test
+    public void testSyntheticResourceCreation() {
+        ResourceResolver resourceResolver = mock(ResourceResolver.class);
+        String path = "/content/synthetic";
+        String resourceType = "/apps/my/resourcetype";
+
+        SyntheticResource syntheticResource = new SyntheticResource(resourceResolver, path, resourceType);
+
+        assertEquals(path, syntheticResource.getPath());
+        assertEquals(resourceType, syntheticResource.getResourceType());
+        assertNotNull(syntheticResource.getResourceMetadata());
+        assertEquals(path, syntheticResource.getResourceMetadata().getResolutionPath());
+        ValueMap vm = syntheticResource.getValueMap();
+        assertNotNull(vm);
+        assertEquals(1, vm.size());
+        assertEquals(resourceType, vm.get(ResourceResolver.PROPERTY_RESOURCE_TYPE, String.class));
+    }
+
+    @Test
+    public void testDerivedSyntheticWithProperties() {
+        ResourceResolver resourceResolver = mock(ResourceResolver.class);
+        String path = "/content/synthetic";
+        String resourceType = "/apps/my/resourcetype";
+
+        SyntheticResource syntheticResource = new SyntheticResource(resourceResolver, path, resourceType);
+        AdapterManager adapterMgr = new AdapterManager() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public <AdapterType> @Nullable AdapterType getAdapter(
+                    @NotNull Object adaptable, @NotNull Class<AdapterType> type) {
+                if (adaptable instanceof SyntheticResource && type == ValueMap.class) {
+                    return (AdapterType)
+                            new ValueMapDecorator(Map.of("foo", "bar", ResourceResolver.PROPERTY_RESOURCE_TYPE, "baz"));
+                }
+                return null;
+            }
+        };
+        SlingAdaptable.setAdapterManager(adapterMgr);
+        try {
+            assertEquals(path, syntheticResource.getPath());
+            assertEquals(resourceType, syntheticResource.getResourceType());
+            assertNotNull(syntheticResource.getResourceMetadata());
+            assertEquals(path, syntheticResource.getResourceMetadata().getResolutionPath());
+            ValueMap vm = syntheticResource.getValueMap();
+            assertNotNull(vm);
+            assertEquals(2, vm.size());
+            assertEquals(resourceType, vm.get(ResourceResolver.PROPERTY_RESOURCE_TYPE, String.class));
+            assertEquals("bar", vm.get("foo", String.class));
+        } finally {
+            SlingAdaptable.unsetAdapterManager(adapterMgr);
+        }
+    }
+}


### PR DESCRIPTION
Related change of JCR Resource Resolver: https://github.com/apache/sling-org-apache-sling-jcr-resource/pull/45