### PR TITLE
SLING-12877 don't re-wrap the request/response if already wrapped

### DIFF
--- a/src/main/java/org/apache/sling/api/scripting/SlingBindings.java
+++ b/src/main/java/org/apache/sling/api/scripting/SlingBindings.java
@@ -215,20 +215,26 @@ public class SlingBindings extends LazyBindings {
     @Override
     public Object put(final String key, final Object value) {
         final Object result = super.put(key, value);
+        // also put the alternate wrapper if it is not already wrapping the same value
         if (REQUEST.equals(key)) {
-            if (value instanceof SlingHttpServletRequest) {
+            if (value instanceof SlingHttpServletRequest
+                    && !(getJakartaRequest() instanceof JavaxToJakartaRequestWrapper rw && rw.getRequest() == value)) {
                 super.put(JAKARTA_REQUEST, JavaxToJakartaRequestWrapper.toJakartaRequest(getRequest()));
             }
         } else if (JAKARTA_REQUEST.equals(key)) {
-            if (value instanceof SlingJakartaHttpServletRequest) {
+            if (value instanceof SlingJakartaHttpServletRequest
+                    && !(getRequest() instanceof JakartaToJavaxRequestWrapper rw && rw.getRequest() == value)) {
                 super.put(REQUEST, JakartaToJavaxRequestWrapper.toJavaxRequest(getJakartaRequest()));
             }
         } else if (RESPONSE.equals(key)) {
-            if (value instanceof SlingHttpServletResponse) {
+            if (value instanceof SlingHttpServletResponse
+                    && !(getJakartaResponse() instanceof JavaxToJakartaResponseWrapper rw
+                            && rw.getResponse() == value)) {
                 super.put(JAKARTA_RESPONSE, JavaxToJakartaResponseWrapper.toJakartaResponse(getResponse()));
             }
         } else if (JAKARTA_RESPONSE.equals(key)) {
-            if (value instanceof SlingJakartaHttpServletResponse) {
+            if (value instanceof SlingJakartaHttpServletResponse
+                    && !(getResponse() instanceof JakartaToJavaxResponseWrapper rw && rw.getResponse() == value)) {
                 super.put(RESPONSE, JakartaToJavaxResponseWrapper.toJavaxResponse(getJakartaResponse()));
             }
         }

--- a/src/test/java/org/apache/sling/api/scripting/SlingBindingsTest.java
+++ b/src/test/java/org/apache/sling/api/scripting/SlingBindingsTest.java
@@ -63,10 +63,22 @@ public class SlingBindingsTest {
         assertTrue(bindings.getRequest() instanceof JakartaToJavaxRequestWrapper);
         assertSame(r, ((JakartaToJavaxRequestWrapper) bindings.getRequest()).getRequest());
 
+        // call the set again with the same param to make sure we are not creating
+        //  a new wrapper object
+        SlingHttpServletRequest original = bindings.getRequest();
+        bindings.setJakartaRequest(r);
+        assertSame(original, bindings.getRequest());
+
         bindings.setRequest(r2);
         assertSame(r2, bindings.getRequest());
         assertTrue(bindings.getJakartaRequest() instanceof JavaxToJakartaRequestWrapper);
         assertSame(r2, ((JavaxToJakartaRequestWrapper) bindings.getJakartaRequest()).getRequest());
+
+        // call the set again with the same param to make sure we are not creating
+        //  a new wrapper object
+        SlingJakartaHttpServletRequest original2 = bindings.getJakartaRequest();
+        bindings.setRequest(r2);
+        assertSame(original2, bindings.getJakartaRequest());
 
         bindings.remove(SlingBindings.JAKARTA_REQUEST);
         assertNull(bindings.getRequest());
@@ -101,10 +113,22 @@ public class SlingBindingsTest {
         assertTrue(bindings.getResponse() instanceof JakartaToJavaxResponseWrapper);
         assertSame(r, ((JakartaToJavaxResponseWrapper) bindings.getResponse()).getResponse());
 
+        // call the set again with the same param to make sure we are not creating
+        //  a new wrapper object
+        SlingHttpServletResponse original = bindings.getResponse();
+        bindings.setJakartaResponse(r);
+        assertSame(original, bindings.getResponse());
+
         bindings.setResponse(r2);
         assertSame(r2, bindings.getResponse());
         assertTrue(bindings.getJakartaResponse() instanceof JavaxToJakartaResponseWrapper);
         assertSame(r2, ((JavaxToJakartaResponseWrapper) bindings.getJakartaResponse()).getResponse());
+
+        // call the set again with the same param to make sure we are not creating
+        //  a new wrapper object
+        SlingJakartaHttpServletResponse original2 = bindings.getJakartaResponse();
+        bindings.setResponse(r2);
+        assertSame(original2, bindings.getJakartaResponse());
 
         bindings.remove(SlingBindings.JAKARTA_RESPONSE);
         assertNull(bindings.getResponse());


### PR DESCRIPTION
Each SlingBindings put of request/response was also wrapping the alternate variation each time it was called.  If a wrapper already exists for the same value, the this is not necessary and looks confusing when debugging.