### PR TITLE
SLING-13194 Resolve build warnings

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,2 +1,2 @@
-Import-Package: javax.jcr;resolution:=optional;version="[2.0,3)", \\
+Import-Package: javax.jcr;resolution:=optional;version="[2.0,3)", \
                 *

--- a/pom.xml
+++ b/pom.xml
@@ -57,19 +57,16 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>6.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.http.wrappers</artifactId>
-            <version>6.1.0</version>
             <scope>provided</scope>
         </dependency>
         <!-- OSGi -->
@@ -82,7 +79,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.17</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -113,7 +109,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.3.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
several dependencies in the pom can remove the version since it is already defined in the parent pom

Also the warning below is logged about the bnd.bnd file:

[WARNING] ../sling-org-apache-sling-api/bnd.bnd [2:86]: Found odd number of backslashes before '*'. These are silently dropped by Java properties parsing and lead to confusing behavior: <<Import-Package: javax.jcr;resolution:=optional;version="[2.0,3)", \\
                *>>